### PR TITLE
5 milestone 3 go backend core implementation

### DIFF
--- a/backend/cmd/server/handlers/blips.go
+++ b/backend/cmd/server/handlers/blips.go
@@ -21,7 +21,7 @@ import (
 // @Failure 404 {object} Error
 // @Failure 500 {object} Error
 // @Router /blips/{id} [get]
-func GetBlip(q *db.Queries) http.HandlerFunc {
+func GetBlip(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {
@@ -61,7 +61,7 @@ func GetBlip(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /blips [post]
-func CreateBlip(q *db.Queries) http.HandlerFunc {
+func CreateBlip(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var params dto.CreateBlipRequest
 		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
@@ -96,7 +96,7 @@ func CreateBlip(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /blips/{id} [delete]
-func DeleteBlip(q *db.Queries) http.HandlerFunc {
+func DeleteBlip(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {
@@ -131,7 +131,7 @@ func DeleteBlip(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /blips/{id} [put]
-func UpdateBlip(q *db.Queries) http.HandlerFunc {
+func UpdateBlip(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {

--- a/backend/cmd/server/handlers/blips_test.go
+++ b/backend/cmd/server/handlers/blips_test.go
@@ -1,0 +1,248 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MasonD-007/template/backend/cmd/server/handlers"
+	"github.com/MasonD-007/template/backend/cmd/server/handlers/mocks"
+	"github.com/MasonD-007/template/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGetBlip(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid id returns bad request",
+			pathID:   "abc",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "not found error returns 404",
+			pathID: "5",
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetBlip", mock.Anything, int32(5)).Return(db.Blip{}, errors.New("not found"))
+			},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:   "successful fetch returns blip",
+			pathID: "7",
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetBlip", mock.Anything, int32(7)).Return(db.Blip{ID: 7, Context: []byte("hello")}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.GetBlip(mockQuerier)
+			req := httptest.NewRequest(http.MethodGet, "/blips/"+tt.pathID, nil)
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			if tt.wantCode == http.StatusOK {
+				var resp map[string]any
+				requireNoErr := json.Unmarshal(recorder.Body.Bytes(), &resp)
+				assert.NoError(t, requireNoErr)
+				assert.Equal(t, float64(7), resp["id"])
+			}
+
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCreateBlip(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "invalid JSON returns bad request",
+			body:     `{"context":123}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "database error returns 500",
+			body: `{"context":"aGVsbG8="}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("CreateBlip", mock.Anything, []byte("hello")).Return(db.Blip{}, errors.New("oops"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name: "successful create returns 201",
+			body: `{"context":"aGVsbG8="}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("CreateBlip", mock.Anything, []byte("hello")).Return(db.Blip{ID: 1, Context: []byte("hello")}, nil)
+			},
+			wantCode: http.StatusCreated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.CreateBlip(mockQuerier)
+			req := httptest.NewRequest(http.MethodPost, "/blips", strings.NewReader(tt.body))
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestUpdateBlip(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		body       string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			body:     `{"context":"aGVsbG8="}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid id returns bad request",
+			pathID:   "abc",
+			body:     `{"context":"aGVsbG8="}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid json returns bad request",
+			pathID:   "1",
+			body:     `{"context":5}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "update error returns 500",
+			pathID: "2",
+			body:   `{"context":"aGVsbG8="}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("UpdateBlip", mock.Anything, db.UpdateBlipParams{ID: 2, Context: []byte("hello")}).Return(db.Blip{}, errors.New("fail"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "successful update returns payload",
+			pathID: "3",
+			body:   `{"context":"aGVsbG8="}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("UpdateBlip", mock.Anything, db.UpdateBlipParams{ID: 3, Context: []byte("hello")}).Return(db.Blip{ID: 3, Context: []byte("hello")}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.UpdateBlip(mockQuerier)
+			req := httptest.NewRequest(http.MethodPut, "/blips/"+tt.pathID, strings.NewReader(tt.body))
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestDeleteBlip(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid id returns bad request",
+			pathID:   "bad",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "delete error returns 500",
+			pathID: "4",
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("DeleteBlip", mock.Anything, int32(4)).Return(errors.New("boom"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "successful delete returns no content",
+			pathID: "6",
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("DeleteBlip", mock.Anything, int32(6)).Return(nil)
+			},
+			wantCode: http.StatusNoContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt := tt
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.DeleteBlip(mockQuerier)
+			req := httptest.NewRequest(http.MethodDelete, "/blips/"+tt.pathID, nil)
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}

--- a/backend/cmd/server/handlers/mocks/querier.go
+++ b/backend/cmd/server/handlers/mocks/querier.go
@@ -1,0 +1,134 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/MasonD-007/template/backend/internal/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockQuerier satisfies handlers.Querier for use in unit tests.
+type MockQuerier struct {
+	mock.Mock
+}
+
+func NewMockQuerier() *MockQuerier {
+	return &MockQuerier{}
+}
+
+func (m *MockQuerier) GetBlip(ctx context.Context, id int32) (db.Blip, error) {
+	args := m.Called(ctx, id)
+	blip, _ := args.Get(0).(db.Blip)
+	return blip, args.Error(1)
+}
+
+func (m *MockQuerier) CreateBlip(ctx context.Context, context []byte) (db.Blip, error) {
+	args := m.Called(ctx, context)
+	blip, _ := args.Get(0).(db.Blip)
+	return blip, args.Error(1)
+}
+
+func (m *MockQuerier) UpdateBlip(ctx context.Context, params db.UpdateBlipParams) (db.Blip, error) {
+	args := m.Called(ctx, params)
+	blip, _ := args.Get(0).(db.Blip)
+	return blip, args.Error(1)
+}
+
+func (m *MockQuerier) DeleteBlip(ctx context.Context, id int32) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockQuerier) GetTechnologyID(ctx context.Context, id pgtype.UUID) (db.Technology, error) {
+	args := m.Called(ctx, id)
+	tech, _ := args.Get(0).(db.Technology)
+	return tech, args.Error(1)
+}
+
+func (m *MockQuerier) GetTechnologyName(ctx context.Context, name string) (db.Technology, error) {
+	args := m.Called(ctx, name)
+	tech, _ := args.Get(0).(db.Technology)
+	return tech, args.Error(1)
+}
+
+func (m *MockQuerier) GetTechnologyQuad(ctx context.Context, quadrantID int32) ([]db.Technology, error) {
+	args := m.Called(ctx, quadrantID)
+	list, _ := args.Get(0).([]db.Technology)
+	return list, args.Error(1)
+}
+
+func (m *MockQuerier) CreateTechnology(ctx context.Context, params db.CreateTechnologyParams) (db.Technology, error) {
+	args := m.Called(ctx, params)
+	tech, _ := args.Get(0).(db.Technology)
+	return tech, args.Error(1)
+}
+
+func (m *MockQuerier) UpdateTechnology(ctx context.Context, params db.UpdateTechnologyParams) (db.Technology, error) {
+	args := m.Called(ctx, params)
+	tech, _ := args.Get(0).(db.Technology)
+	return tech, args.Error(1)
+}
+
+func (m *MockQuerier) DeleteTechnology(ctx context.Context, id pgtype.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockQuerier) GetUserID(ctx context.Context, id pgtype.UUID) (db.User, error) {
+	args := m.Called(ctx, id)
+	user, _ := args.Get(0).(db.User)
+	return user, args.Error(1)
+}
+
+func (m *MockQuerier) GetUserEmail(ctx context.Context, email string) (db.User, error) {
+	args := m.Called(ctx, email)
+	user, _ := args.Get(0).(db.User)
+	return user, args.Error(1)
+}
+
+func (m *MockQuerier) CreateUser(ctx context.Context, params db.CreateUserParams) (db.User, error) {
+	args := m.Called(ctx, params)
+	user, _ := args.Get(0).(db.User)
+	return user, args.Error(1)
+}
+
+func (m *MockQuerier) UpdateUser(ctx context.Context, params db.UpdateUserParams) (db.User, error) {
+	args := m.Called(ctx, params)
+	user, _ := args.Get(0).(db.User)
+	return user, args.Error(1)
+}
+
+func (m *MockQuerier) DeleteUser(ctx context.Context, id pgtype.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockQuerier) GetUserTechnologyID(ctx context.Context, id pgtype.UUID) (db.UserTechnology, error) {
+	args := m.Called(ctx, id)
+	ut, _ := args.Get(0).(db.UserTechnology)
+	return ut, args.Error(1)
+}
+
+func (m *MockQuerier) GetUserTechnologyUserId(ctx context.Context, userID pgtype.UUID) ([]db.UserTechnology, error) {
+	args := m.Called(ctx, userID)
+	list, _ := args.Get(0).([]db.UserTechnology)
+	return list, args.Error(1)
+}
+
+func (m *MockQuerier) CreateUserTechnology(ctx context.Context, params db.CreateUserTechnologyParams) (db.UserTechnology, error) {
+	args := m.Called(ctx, params)
+	ut, _ := args.Get(0).(db.UserTechnology)
+	return ut, args.Error(1)
+}
+
+func (m *MockQuerier) UpdateUserTechnology(ctx context.Context, params db.UpdateUserTechnologyParams) (db.UserTechnology, error) {
+	args := m.Called(ctx, params)
+	ut, _ := args.Get(0).(db.UserTechnology)
+	return ut, args.Error(1)
+}
+
+func (m *MockQuerier) DeleteUserTechnology(ctx context.Context, id pgtype.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}

--- a/backend/cmd/server/handlers/querier.go
+++ b/backend/cmd/server/handlers/querier.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/MasonD-007/template/backend/internal/db"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// Querier captures the database operations required by the HTTP handlers.
+type Querier interface {
+	// Blips
+	GetBlip(ctx context.Context, id int32) (db.Blip, error)
+	CreateBlip(ctx context.Context, context []byte) (db.Blip, error)
+	UpdateBlip(ctx context.Context, params db.UpdateBlipParams) (db.Blip, error)
+	DeleteBlip(ctx context.Context, id int32) error
+
+	// Technologies
+	GetTechnologyID(ctx context.Context, id pgtype.UUID) (db.Technology, error)
+	GetTechnologyName(ctx context.Context, name string) (db.Technology, error)
+	GetTechnologyQuad(ctx context.Context, quadrantID int32) ([]db.Technology, error)
+	CreateTechnology(ctx context.Context, params db.CreateTechnologyParams) (db.Technology, error)
+	UpdateTechnology(ctx context.Context, params db.UpdateTechnologyParams) (db.Technology, error)
+	DeleteTechnology(ctx context.Context, id pgtype.UUID) error
+
+	// Users
+	GetUserID(ctx context.Context, id pgtype.UUID) (db.User, error)
+	GetUserEmail(ctx context.Context, email string) (db.User, error)
+	CreateUser(ctx context.Context, params db.CreateUserParams) (db.User, error)
+	UpdateUser(ctx context.Context, params db.UpdateUserParams) (db.User, error)
+	DeleteUser(ctx context.Context, id pgtype.UUID) error
+
+	// User Technologies
+	GetUserTechnologyID(ctx context.Context, id pgtype.UUID) (db.UserTechnology, error)
+	GetUserTechnologyUserId(ctx context.Context, userID pgtype.UUID) ([]db.UserTechnology, error)
+	CreateUserTechnology(ctx context.Context, params db.CreateUserTechnologyParams) (db.UserTechnology, error)
+	UpdateUserTechnology(ctx context.Context, params db.UpdateUserTechnologyParams) (db.UserTechnology, error)
+	DeleteUserTechnology(ctx context.Context, id pgtype.UUID) error
+}

--- a/backend/cmd/server/handlers/technologies.go
+++ b/backend/cmd/server/handlers/technologies.go
@@ -23,7 +23,7 @@ import (
 // @Failure 404 {object} Error
 // @Failure 500 {object} Error
 // @Router /technologies/{id} [get]
-func GetTechnology(q *db.Queries) http.HandlerFunc {
+func GetTechnology(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {
@@ -64,7 +64,7 @@ func GetTechnology(q *db.Queries) http.HandlerFunc {
 // @Failure 404 {object} Error
 // @Failure 500 {object} Error
 // @Router /technologies/by-name/{name} [get]
-func GetTechnologyByName(q *db.Queries) http.HandlerFunc {
+func GetTechnologyByName(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := r.PathValue("name")
 		if name == "" {
@@ -98,7 +98,7 @@ func GetTechnologyByName(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /technologies/by-quadrant/{quadrant_id} [get]
-func GetTechnologiesByQuadrant(q *db.Queries) http.HandlerFunc {
+func GetTechnologiesByQuadrant(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		quadrantIDStr := r.PathValue("quadrant_id")
 		if quadrantIDStr == "" {
@@ -142,7 +142,7 @@ func GetTechnologiesByQuadrant(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /technologies [post]
-func CreateTechnology(q *db.Queries) http.HandlerFunc {
+func CreateTechnology(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var params dto.CreateTechnologyRequest
 		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
@@ -182,7 +182,7 @@ func CreateTechnology(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /technologies/{id} [delete]
-func DeleteTechnology(q *db.Queries) http.HandlerFunc {
+func DeleteTechnology(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {
@@ -217,7 +217,7 @@ func DeleteTechnology(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /technologies/{id} [put]
-func UpdateTechnology(q *db.Queries) http.HandlerFunc {
+func UpdateTechnology(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {

--- a/backend/cmd/server/handlers/technologies_test.go
+++ b/backend/cmd/server/handlers/technologies_test.go
@@ -1,0 +1,355 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MasonD-007/template/backend/cmd/server/handlers"
+	"github.com/MasonD-007/template/backend/cmd/server/handlers/mocks"
+	"github.com/MasonD-007/template/backend/internal/db"
+	"github.com/MasonD-007/template/backend/internal/uuidutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var validUUIDStr = "550e8400-e29b-41d4-a716-446655440000"
+var validUUID, _ = uuidutil.Parse(validUUIDStr)
+
+func TestGetTechnology(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid uuid returns bad request",
+			pathID:   "invalid-uuid",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "not found error returns 404",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetTechnologyID", mock.Anything, validUUID).Return(db.Technology{}, errors.New("not found"))
+			},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:   "successful fetch returns technology",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetTechnologyID", mock.Anything, validUUID).Return(db.Technology{ID: validUUID, Name: "Go"}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.GetTechnology(mockQuerier)
+			req := httptest.NewRequest(http.MethodGet, "/technologies/"+tt.pathID, nil)
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			if tt.wantCode == http.StatusOK {
+				var resp map[string]any
+				requireNoErr := json.Unmarshal(recorder.Body.Bytes(), &resp)
+				assert.NoError(t, requireNoErr)
+				assert.Equal(t, "Go", resp["name"])
+			}
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetTechnologyByName(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathName   string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing name returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "not found error returns 404",
+			pathName: "UnknownTech",
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetTechnologyName", mock.Anything, "UnknownTech").Return(db.Technology{}, errors.New("not found"))
+			},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "successful fetch returns technology",
+			pathName: "React",
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetTechnologyName", mock.Anything, "React").Return(db.Technology{Name: "React"}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.GetTechnologyByName(mockQuerier)
+			req := httptest.NewRequest(http.MethodGet, "/technologies/by-name/"+tt.pathName, nil)
+			if tt.pathName != "" {
+				req.SetPathValue("name", tt.pathName)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetTechnologiesByQuadrant(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathQuadID string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing quadrant id returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid quadrant id returns bad request",
+			pathQuadID: "abc",
+			wantCode:   http.StatusBadRequest,
+		},
+		{
+			name:       "fetch error returns 500",
+			pathQuadID: "1",
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetTechnologyQuad", mock.Anything, int32(1)).Return([]db.Technology(nil), errors.New("db error"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:       "successful fetch returns list",
+			pathQuadID: "2",
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetTechnologyQuad", mock.Anything, int32(2)).Return([]db.Technology{{Name: "Tech1"}}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.GetTechnologiesByQuadrant(mockQuerier)
+			req := httptest.NewRequest(http.MethodGet, "/technologies/by-quadrant/"+tt.pathQuadID, nil)
+			if tt.pathQuadID != "" {
+				req.SetPathValue("quadrant_id", tt.pathQuadID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCreateTechnology(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "invalid JSON returns bad request",
+			body:     `{invalid}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "database error returns 500",
+			body: `{"id":"` + validUUIDStr + `", "name":"NewTech", "blip_id":1, "quadrant_id":2}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("CreateTechnology", mock.Anything, mock.AnythingOfType("db.CreateTechnologyParams")).Return(db.Technology{}, errors.New("db error"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name: "successful create returns 201",
+			body: `{"id":"` + validUUIDStr + `", "name":"NewTech", "blip_id":1, "quadrant_id":2}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("CreateTechnology", mock.Anything, mock.AnythingOfType("db.CreateTechnologyParams")).Return(db.Technology{ID: validUUID, Name: "NewTech"}, nil)
+			},
+			wantCode: http.StatusCreated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.CreateTechnology(mockQuerier)
+			req := httptest.NewRequest(http.MethodPost, "/technologies", strings.NewReader(tt.body))
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestUpdateTechnology(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		body       string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			body:     `{"name":"UpdatedTech"}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid id returns bad request",
+			pathID:   "invalid-uuid",
+			body:     `{"name":"UpdatedTech"}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid json returns bad request",
+			pathID:   validUUIDStr,
+			body:     `{bad}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "update error returns 500",
+			pathID: validUUIDStr,
+			body:   `{"name":"UpdatedTech"}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("UpdateTechnology", mock.Anything, mock.AnythingOfType("db.UpdateTechnologyParams")).Return(db.Technology{}, errors.New("fail"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "successful update returns payload",
+			pathID: validUUIDStr,
+			body:   `{"name":"UpdatedTech"}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("UpdateTechnology", mock.Anything, mock.AnythingOfType("db.UpdateTechnologyParams")).Return(db.Technology{ID: validUUID, Name: "UpdatedTech"}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.UpdateTechnology(mockQuerier)
+			req := httptest.NewRequest(http.MethodPut, "/technologies/"+tt.pathID, strings.NewReader(tt.body))
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestDeleteTechnology(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid id returns bad request",
+			pathID:   "invalid-uuid",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "delete error returns 500",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("DeleteTechnology", mock.Anything, validUUID).Return(errors.New("boom"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "successful delete returns no content",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("DeleteTechnology", mock.Anything, validUUID).Return(nil)
+			},
+			wantCode: http.StatusNoContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.DeleteTechnology(mockQuerier)
+			req := httptest.NewRequest(http.MethodDelete, "/technologies/"+tt.pathID, nil)
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}

--- a/backend/cmd/server/handlers/users.go
+++ b/backend/cmd/server/handlers/users.go
@@ -22,7 +22,7 @@ import (
 // @Failure 404 {object} Error
 // @Failure 500 {object} Error
 // @Router /users/{id} [get]
-func GetUser(q *db.Queries) http.HandlerFunc {
+func GetUser(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {
@@ -63,7 +63,7 @@ func GetUser(q *db.Queries) http.HandlerFunc {
 // @Failure 404 {object} Error
 // @Failure 500 {object} Error
 // @Router /users/by-email/{email} [get]
-func GetUserByEmail(q *db.Queries) http.HandlerFunc {
+func GetUserByEmail(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		email := r.PathValue("email")
 		if email == "" {
@@ -97,7 +97,7 @@ func GetUserByEmail(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /users [post]
-func CreateUser(q *db.Queries) http.HandlerFunc {
+func CreateUser(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var params dto.CreateUserRequest
 		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
@@ -139,7 +139,7 @@ func CreateUser(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /users/{id} [delete]
-func DeleteUser(q *db.Queries) http.HandlerFunc {
+func DeleteUser(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {
@@ -174,7 +174,7 @@ func DeleteUser(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /users/{id} [put]
-func UpdateUser(q *db.Queries) http.HandlerFunc {
+func UpdateUser(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {

--- a/backend/cmd/server/handlers/users_test.go
+++ b/backend/cmd/server/handlers/users_test.go
@@ -1,0 +1,296 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MasonD-007/template/backend/cmd/server/handlers"
+	"github.com/MasonD-007/template/backend/cmd/server/handlers/mocks"
+	"github.com/MasonD-007/template/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGetUser(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid uuid returns bad request",
+			pathID:   "invalid-uuid",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "not found error returns 404",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetUserID", mock.Anything, validUUID).Return(db.User{}, errors.New("not found"))
+			},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:   "successful fetch returns user",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetUserID", mock.Anything, validUUID).Return(db.User{ID: validUUID, Email: "test@example.com"}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.GetUser(mockQuerier)
+			req := httptest.NewRequest(http.MethodGet, "/users/"+tt.pathID, nil)
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			if tt.wantCode == http.StatusOK {
+				var resp map[string]any
+				requireNoErr := json.Unmarshal(recorder.Body.Bytes(), &resp)
+				assert.NoError(t, requireNoErr)
+				assert.Equal(t, "test@example.com", resp["email"])
+			}
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetUserByEmail(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathEmail  string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing email returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:      "not found error returns 404",
+			pathEmail: "unknown@example.com",
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetUserEmail", mock.Anything, "unknown@example.com").Return(db.User{}, errors.New("not found"))
+			},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:      "successful fetch returns user",
+			pathEmail: "found@example.com",
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetUserEmail", mock.Anything, "found@example.com").Return(db.User{Email: "found@example.com"}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.GetUserByEmail(mockQuerier)
+			req := httptest.NewRequest(http.MethodGet, "/users/by-email/"+tt.pathEmail, nil)
+			if tt.pathEmail != "" {
+				req.SetPathValue("email", tt.pathEmail)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCreateUser(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "invalid JSON returns bad request",
+			body:     `{bad json}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "database error returns 500",
+			body: `{"email":"test@test.com", "username":"testuser"}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("CreateUser", mock.Anything, mock.AnythingOfType("db.CreateUserParams")).Return(db.User{}, errors.New("db error"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name: "successful create returns 201",
+			body: `{"email":"test@test.com", "username":"testuser"}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("CreateUser", mock.Anything, mock.AnythingOfType("db.CreateUserParams")).Return(db.User{Email: "test@test.com"}, nil)
+			},
+			wantCode: http.StatusCreated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.CreateUser(mockQuerier)
+			req := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader(tt.body))
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestUpdateUser(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		body       string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			body:     `{"email":"new@example.com"}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid id returns bad request",
+			pathID:   "invalid-uuid",
+			body:     `{"email":"new@example.com"}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid json returns bad request",
+			pathID:   validUUIDStr,
+			body:     `{bad json}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "update error returns 500",
+			pathID: validUUIDStr,
+			body:   `{"email":"new@example.com"}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("UpdateUser", mock.Anything, mock.AnythingOfType("db.UpdateUserParams")).Return(db.User{}, errors.New("fail"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "successful update returns payload",
+			pathID: validUUIDStr,
+			body:   `{"email":"new@example.com"}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("UpdateUser", mock.Anything, mock.AnythingOfType("db.UpdateUserParams")).Return(db.User{Email: "new@example.com"}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.UpdateUser(mockQuerier)
+			req := httptest.NewRequest(http.MethodPut, "/users/"+tt.pathID, strings.NewReader(tt.body))
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid id returns bad request",
+			pathID:   "invalid-uuid",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "delete error returns 500",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("DeleteUser", mock.Anything, validUUID).Return(errors.New("boom"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "successful delete returns no content",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("DeleteUser", mock.Anything, validUUID).Return(nil)
+			},
+			wantCode: http.StatusNoContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.DeleteUser(mockQuerier)
+			req := httptest.NewRequest(http.MethodDelete, "/users/"+tt.pathID, nil)
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}

--- a/backend/cmd/server/handlers/usertechnologes.go
+++ b/backend/cmd/server/handlers/usertechnologes.go
@@ -22,7 +22,7 @@ import (
 // @Failure 404 {object} Error
 // @Failure 500 {object} Error
 // @Router /user-technologies/{id} [get]
-func GetUserTechnology(q *db.Queries) http.HandlerFunc {
+func GetUserTechnology(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {
@@ -62,7 +62,7 @@ func GetUserTechnology(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /users/{user_id}/technologies [get]
-func GetUserTechnologiesByUser(q *db.Queries) http.HandlerFunc {
+func GetUserTechnologiesByUser(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		userIDStr := r.PathValue("user_id")
 		if userIDStr == "" {
@@ -106,7 +106,7 @@ func GetUserTechnologiesByUser(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /user-technologies [post]
-func CreateUserTechnology(q *db.Queries) http.HandlerFunc {
+func CreateUserTechnology(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var params dto.CreateUserTechnologyRequest
 		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
@@ -146,7 +146,7 @@ func CreateUserTechnology(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /user-technologies/{id} [delete]
-func DeleteUserTechnology(q *db.Queries) http.HandlerFunc {
+func DeleteUserTechnology(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {
@@ -181,7 +181,7 @@ func DeleteUserTechnology(q *db.Queries) http.HandlerFunc {
 // @Failure 400 {object} Error
 // @Failure 500 {object} Error
 // @Router /user-technologies/{id} [put]
-func UpdateUserTechnology(q *db.Queries) http.HandlerFunc {
+func UpdateUserTechnology(q Querier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		if idStr == "" {

--- a/backend/cmd/server/handlers/usertechnologes_test.go
+++ b/backend/cmd/server/handlers/usertechnologes_test.go
@@ -1,0 +1,301 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MasonD-007/template/backend/cmd/server/handlers"
+	"github.com/MasonD-007/template/backend/cmd/server/handlers/mocks"
+	"github.com/MasonD-007/template/backend/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGetUserTechnology(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid uuid returns bad request",
+			pathID:   "invalid-uuid",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "not found error returns 404",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetUserTechnologyID", mock.Anything, validUUID).Return(db.UserTechnology{}, errors.New("not found"))
+			},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:   "successful fetch returns user technology",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetUserTechnologyID", mock.Anything, validUUID).Return(db.UserTechnology{ID: validUUID, RingID: 3}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.GetUserTechnology(mockQuerier)
+			req := httptest.NewRequest(http.MethodGet, "/user-technologies/"+tt.pathID, nil)
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			if tt.wantCode == http.StatusOK {
+				var resp map[string]any
+				requireNoErr := json.Unmarshal(recorder.Body.Bytes(), &resp)
+				assert.NoError(t, requireNoErr)
+				assert.Equal(t, float64(3), resp["ring_id"])
+			}
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetUserTechnologiesByUser(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathUserID string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing user id returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid user id returns bad request",
+			pathUserID: "invalid-uuid",
+			wantCode:   http.StatusBadRequest,
+		},
+		{
+			name:       "fetch error returns 500",
+			pathUserID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetUserTechnologyUserId", mock.Anything, validUUID).Return([]db.UserTechnology(nil), errors.New("db error"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:       "successful fetch returns list",
+			pathUserID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("GetUserTechnologyUserId", mock.Anything, validUUID).Return([]db.UserTechnology{{RingID: 2}}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.GetUserTechnologiesByUser(mockQuerier)
+			req := httptest.NewRequest(http.MethodGet, "/user-technologies/user/"+tt.pathUserID, nil)
+			if tt.pathUserID != "" {
+				req.SetPathValue("user_id", tt.pathUserID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCreateUserTechnology(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "invalid JSON returns bad request",
+			body:     `{bad json}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "database error returns 500",
+			body: `{"user_id":"` + validUUIDStr + `", "technology_id":"` + validUUIDStr + `", "ring_id":1}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("CreateUserTechnology", mock.Anything, mock.AnythingOfType("db.CreateUserTechnologyParams")).Return(db.UserTechnology{}, errors.New("db error"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name: "successful create returns 201",
+			body: `{"user_id":"` + validUUIDStr + `", "technology_id":"` + validUUIDStr + `", "ring_id":1}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("CreateUserTechnology", mock.Anything, mock.AnythingOfType("db.CreateUserTechnologyParams")).Return(db.UserTechnology{ID: validUUID, RingID: 1}, nil)
+			},
+			wantCode: http.StatusCreated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.CreateUserTechnology(mockQuerier)
+			req := httptest.NewRequest(http.MethodPost, "/user-technologies", strings.NewReader(tt.body))
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestUpdateUserTechnology(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		body       string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			body:     `{"ring_id":2}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid id returns bad request",
+			pathID:   "invalid-uuid",
+			body:     `{"ring_id":2}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid json returns bad request",
+			pathID:   validUUIDStr,
+			body:     `{bad}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "update error returns 500",
+			pathID: validUUIDStr,
+			body:   `{"ring_id":2}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("UpdateUserTechnology", mock.Anything, mock.AnythingOfType("db.UpdateUserTechnologyParams")).Return(db.UserTechnology{}, errors.New("fail"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "successful update returns payload",
+			pathID: validUUIDStr,
+			body:   `{"ring_id":2}`,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("UpdateUserTechnology", mock.Anything, mock.AnythingOfType("db.UpdateUserTechnologyParams")).Return(db.UserTechnology{ID: validUUID, RingID: 2}, nil)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.UpdateUserTechnology(mockQuerier)
+			req := httptest.NewRequest(http.MethodPut, "/user-technologies/"+tt.pathID, strings.NewReader(tt.body))
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+func TestDeleteUserTechnology(t *testing.T) {
+	tests := []struct {
+		name       string
+		pathID     string
+		mockExpect func(*mocks.MockQuerier)
+		wantCode   int
+	}{
+		{
+			name:     "missing id returns bad request",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "invalid id returns bad request",
+			pathID:   "invalid-uuid",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:   "delete error returns 500",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("DeleteUserTechnology", mock.Anything, validUUID).Return(errors.New("boom"))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name:   "successful delete returns no content",
+			pathID: validUUIDStr,
+			mockExpect: func(m *mocks.MockQuerier) {
+				m.On("DeleteUserTechnology", mock.Anything, validUUID).Return(nil)
+			},
+			wantCode: http.StatusNoContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQuerier := mocks.NewMockQuerier()
+			if tt.mockExpect != nil {
+				tt.mockExpect(mockQuerier)
+			}
+
+			handler := handlers.DeleteUserTechnology(mockQuerier)
+			req := httptest.NewRequest(http.MethodDelete, "/user-technologies/"+tt.pathID, nil)
+			if tt.pathID != "" {
+				req.SetPathValue("id", tt.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			handler(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			mockQuerier.AssertExpectations(t)
+		})
+	}
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	log.Printf("[%s] [INFO] [main] [DB_CONNECTED]", time.Now().Format(time.RFC3339))
 
-	if err := migrate.RunMigrations(context.Background(), conn); err != nil {
+	if err := migrate.RunMigrations(context.Background(), dbURL); err != nil {
 		log.Fatalf("Failed to run migrations: %v", err)
 	}
 

--- a/backend/cmd/server/middleware_test.go
+++ b/backend/cmd/server/middleware_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggingMiddleware(t *testing.T) {
+	var logBuffer bytes.Buffer
+	originalWriter := log.Writer()
+	log.SetOutput(&logBuffer)
+	defer log.SetOutput(originalWriter)
+
+	var forwardedBody string
+	handler := loggingMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := io.ReadAll(r.Body)
+		forwardedBody = string(data)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("done"))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/health", strings.NewReader(`{"ok":true}`))
+	req.RemoteAddr = "127.0.0.1:1234"
+	recorder := httptest.NewRecorder()
+	handler(recorder, req)
+
+	assert.Equal(t, http.StatusCreated, recorder.Code)
+	assert.Equal(t, `{"ok":true}`, forwardedBody)
+	logs := logBuffer.String()
+	assert.Contains(t, logs, "body={\"ok\":true}")
+	assert.Contains(t, logs, "status=201")
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,7 @@ module github.com/MasonD-007/template/backend
 go 1.26.1
 
 require (
+	github.com/go-chi/chi/v5 v5.2.5
 	github.com/golang-migrate/migrate/v4 v4.18.2
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
@@ -13,7 +14,6 @@ require (
 
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
-	github.com/go-chi/chi/v5 v5.2.5 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/spec v0.20.6 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -8,12 +8,14 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/joho/godotenv v1.5.1
+	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/http-swagger/v2 v2.0.2
 	github.com/swaggo/swag v1.16.6
 )
 
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/spec v0.20.6 // indirect
@@ -26,7 +28,9 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/swaggo/files/v2 v2.0.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/mod v0.27.0 // indirect
@@ -34,4 +38,5 @@ require (
 	golang.org/x/text v0.29.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -94,6 +94,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/backend/internal/db/migrate/migrate.go
+++ b/backend/internal/db/migrate/migrate.go
@@ -10,33 +10,13 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/pgx/v5"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // RunMigrations runs all pending database migrations
-func RunMigrations(ctx context.Context, pool *pgxpool.Pool) error {
-	// Get a database/sql connection from pgx
-	connConfig := pool.Config().ConnConfig
+func RunMigrations(ctx context.Context, dbURL string) error {
+	_ = ctx
 
-	// Build DSN with appropriate sslmode
-	var dsn string
-	if connConfig.TLSConfig == nil {
-		dsn = fmt.Sprintf("postgresql://%s:%s@%s/%s?sslmode=disable",
-			connConfig.User,
-			connConfig.Password,
-			connConfig.Host,
-			connConfig.Database,
-		)
-	} else {
-		dsn = fmt.Sprintf("postgresql://%s:%s@%s/%s?sslmode=require",
-			connConfig.User,
-			connConfig.Password,
-			connConfig.Host,
-			connConfig.Database,
-		)
-	}
-
-	db, err := sql.Open("pgx", dsn)
+	db, err := sql.Open("pgx", dbURL)
 	if err != nil {
 		return fmt.Errorf("failed to open database for migrations: %w", err)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   postgres:
     image: postgres:16-alpine


### PR DESCRIPTION
This pull request introduces a new abstraction layer for database access in the HTTP handlers by defining a `Querier` interface. It refactors the handler functions to accept this interface instead of concrete database query implementations, enabling easier unit testing and better separation of concerns. The PR also adds comprehensive unit tests for the blip handlers and provides a mock implementation of the `Querier` for testing purposes.

Key changes include:

**Abstraction and Refactoring:**

* Introduced a new `Querier` interface in `handlers/querier.go` that encapsulates all database operations required by the HTTP handlers, covering blips, technologies, users, and user technologies.
* Refactored all handler functions in `blips.go` and `technologies.go` to accept a `Querier` interface instead of a concrete `*db.Queries` type, improving testability and flexibility. [[1]](diffhunk://#diff-b9ec1639a24dd966e9d9fae3baa95c1b50a2268d459cc7d693758ae2b5b16965L24-R24) [[2]](diffhunk://#diff-b9ec1639a24dd966e9d9fae3baa95c1b50a2268d459cc7d693758ae2b5b16965L64-R64) [[3]](diffhunk://#diff-b9ec1639a24dd966e9d9fae3baa95c1b50a2268d459cc7d693758ae2b5b16965L99-R99) [[4]](diffhunk://#diff-b9ec1639a24dd966e9d9fae3baa95c1b50a2268d459cc7d693758ae2b5b16965L134-R134) [[5]](diffhunk://#diff-11a5277ab9735b769553cb56603902a718e8dfd210e7bf83ba31d6a1921a948fL26-R26) [[6]](diffhunk://#diff-11a5277ab9735b769553cb56603902a718e8dfd210e7bf83ba31d6a1921a948fL67-R67) [[7]](diffhunk://#diff-11a5277ab9735b769553cb56603902a718e8dfd210e7bf83ba31d6a1921a948fL101-R101) [[8]](diffhunk://#diff-11a5277ab9735b769553cb56603902a718e8dfd210e7bf83ba31d6a1921a948fL145-R145) [[9]](diffhunk://#diff-11a5277ab9735b769553cb56603902a718e8dfd210e7bf83ba31d6a1921a948fL185-R185) [[10]](diffhunk://#diff-11a5277ab9735b769553cb56603902a718e8dfd210e7bf83ba31d6a1921a948fL220-R220)

**Testing Improvements:**

* Added a new mock implementation of the `Querier` interface in `handlers/mocks/querier.go` using testify's `mock.Mock`, enabling fine-grained control over database interactions in tests.
* Implemented thorough unit tests for all blip handler endpoints in `handlers/blips_test.go`, covering various edge cases and error scenarios using the new mock querier.

These changes make the codebase more modular, maintainable, and testable, especially for the HTTP handler layer.